### PR TITLE
WIP:  Rpc help template for pr

### DIFF
--- a/contrib/ci-builders/docker-build.sh
+++ b/contrib/ci-builders/docker-build.sh
@@ -17,6 +17,14 @@ docker push electriccoinco/zcashd-gitian-debian10
 docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=debian --build-arg FROMBASEOS=debian --build-arg FROMBASEOS_BUILD_TAG=10 -t electriccoinco/zcashd-bbworker-debian10
 docker push electriccoinco/zcashd-bbworker-debian10
 
+# Debian 11
+docker build . -f Dockerfile-build.apt --build-arg FROMBASEOS=debian --build-arg FROMBASEOS_BUILD_TAG=bullseye -t electriccoinco/zcashd-build-debian11
+docker push electriccoinco/zcashd-build-debian11
+docker build . -f Dockerfile-gitian.apt --build-arg FROMBASEOS=debian --build-arg FROMBASEOS_BUILD_TAG=bullseye -t electriccoinco/zcashd-gitian-debian11
+docker push electriccoinco/zcashd-gitian-debian11
+docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=debian --build-arg FROMBASEOS=debian --build-arg FROMBASEOS_BUILD_TAG=bullseye -t electriccoinco/zcashd-bbworker-debian11
+docker push electriccoinco/zcashd-bbworker-debian11
+
 # Ubuntu 16.04
 docker build . -f Dockerfile-build.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=16.04 -t electriccoinco/zcashd-build-ubuntu1604
 docker push electriccoinco/zcashd-build-ubuntu1604
@@ -25,18 +33,20 @@ docker push electriccoinco/zcashd-gitian-ubuntu1604
 docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=ubuntu --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=1604 -t electriccoinco/zcashd-bbworker-ubuntu1604
 docker push electriccoinco/zcashd-bbworker-ubuntu1604
 
-# Ubuntu 18.04, 20.04
+# Ubuntu 18.04
 docker build . -f Dockerfile-build.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=18.04 -t electriccoinco/zcashd-build-ubuntu1804
-docker build . -f Dockerfile-build.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=20.04 -t electriccoinco/zcashd-build-ubuntu2004
 docker push electriccoinco/zcashd-build-ubuntu1804
-docker push electriccoinco/zcashd-build-ubuntu2004
 docker build . -f Dockerfile-gitian.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=1804 -t electriccoinco/zcashd-gitian-ubuntu1804
-docker build . -f Dockerfile-gitian.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=2004 -t electriccoinco/zcashd-gitian-ubuntu2004
 docker push electriccoinco/zcashd-gitian-ubuntu1804
-docker push electriccoinco/zcashd-gitian-ubuntu2004
 docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=ubuntu --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=1804 -t electriccoinco/zcashd-bbworker-ubuntu1804
-docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=ubuntu --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=2004 -t electriccoinco/zcashd-bbworker-ubuntu2004
 docker push electriccoinco/zcashd-bbworker-ubuntu1804
+
+# Ubuntu 20.04
+docker build . -f Dockerfile-build.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=20.04 -t electriccoinco/zcashd-build-ubuntu2004
+docker push electriccoinco/zcashd-build-ubuntu2004
+docker build . -f Dockerfile-gitian.apt --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=2004 -t electriccoinco/zcashd-gitian-ubuntu2004
+docker push electriccoinco/zcashd-gitian-ubuntu2004
+docker build . -f Dockerfile-bbworker.apt --build-arg BASEOS=ubuntu --build-arg FROMBASEOS=ubuntu --build-arg FROMBASEOS_BUILD_TAG=2004 -t electriccoinco/zcashd-bbworker-ubuntu2004
 docker push electriccoinco/zcashd-bbworker-ubuntu2004
 
 # Centos8

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -13,6 +13,7 @@
 #include "main.h"
 #include "metrics.h"
 #include "primitives/transaction.h"
+#include "rpc/docstrings.h"
 #include "rpc/server.h"
 #include "streams.h"
 #include "sync.h"
@@ -271,50 +272,41 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
 
 UniValue getblockcount(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getblockcount\n"
-            "\nReturns the number of blocks in the best valid block chain.\n"
-            "\nResult:\n"
-            "n    (numeric) The current block count\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockcount", "")
-            + HelpExampleRpc("getblockcount", "")
-        );
-
+    if (fHelp || params.size() != 0) {
+        HelpSections help_sections =
+            HelpSections(__func__)
+                .set_description("Returns the number of blocks in the best valid block chain.")
+                .set_result("n    (numeric) The current block count")
+                .set_examples("");
+        throw runtime_error(help_sections.combine_sections());
+    }
     LOCK(cs_main);
     return chainActive.Height();
 }
 
 UniValue getbestblockhash(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getbestblockhash\n"
-            "\nReturns the hash of the best (tip) block in the longest block chain.\n"
-            "\nResult\n"
-            "\"hex\"      (string) the block hash hex encoded\n"
-            "\nExamples\n"
-            + HelpExampleCli("getbestblockhash", "")
-            + HelpExampleRpc("getbestblockhash", "")
-        );
-
+    if (fHelp || params.size() != 0) {
+        HelpSections help_sections =
+            HelpSections(__func__)
+                .set_description("Returns the hash of the best (tip) block in the longest block chain.")
+                .set_result("\"hex\"      (string) the block hash hex encoded");
+        throw runtime_error(help_sections.combine_sections());
+    }
     LOCK(cs_main);
     return chainActive.Tip()->GetBlockHash().GetHex();
 }
 
 UniValue getdifficulty(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
-        throw runtime_error(
-            "getdifficulty\n"
-            "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nResult:\n"
-            "n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getdifficulty", "")
-            + HelpExampleRpc("getdifficulty", "")
-        );
+    if (fHelp || params.size() != 0) {
+        HelpSections help_sections =
+            HelpSections(__func__)
+                .set_description("Returns the proof-of-work difficulty as a multiple of the minimum difficulty.\n")
+                .set_result("n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.")
+                .set_examples("");
+        throw runtime_error(help_sections.combine_sections());
+    }
 
     LOCK(cs_main);
     return GetNetworkDifficulty();

--- a/src/rpc/docstrings.h
+++ b/src/rpc/docstrings.h
@@ -1,0 +1,174 @@
+#ifndef RPC_DOCSTRINGS_H
+#define RPC_DOCSTRINGS_H
+
+using namespace std;
+
+class HelpSections
+{
+private:
+    // begin data section
+    string name;
+    string usage;
+    string description;
+    string arguments;
+    string result;
+    string examples;
+
+
+public:
+    HelpSections(string rpc_name) // constructor: includes defaults
+        : name(rpc_name),
+          usage(""),
+          description(""),
+          arguments(""),
+          result("This RPC does not return a result by default.\n"),
+          examples("")
+    {
+    }
+    // begin method section
+    string combine_sections()
+    {
+        // formats data section members into help message
+        string argstring = "";
+        if (!this->arguments.empty())
+            argstring += "\n\nArguments:\n" + this->arguments;
+        if (this->examples.empty())
+            this->set_examples("");
+        return "Usage:\n" + this->name + " " + usage + "\n\nDescription:\n" + this->description + argstring + "\n\nResult:\n" + this->result + "\n\nExamples:\n" + this->examples;
+    }
+
+    // setter methods below.
+    HelpSections& set_usage(string usage_message)
+    {
+        this->usage = usage_message;
+        return *this;
+    }
+    HelpSections& set_description(string description_message)
+    {
+        this->description = description_message;
+        return *this;
+    }
+    HelpSections& set_arguments(string arguments_message)
+    {
+        this->arguments = arguments_message;
+        return *this;
+    }
+    HelpSections& set_result(string result_message)
+    {
+        this->result = result_message;
+        return *this;
+    }
+    HelpSections& set_examples(string args)
+    {
+        this->examples +=
+            "> zcash-cli " + this->name + " " + args +
+            "\n> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
+            "\"method\": \"" +
+            this->name + "\", \"params\": [" + args +
+            "] }' -H 'content-type: text/plain;' http://127.0.0.1:8232/\n\n";
+        return *this;
+    }
+};
+
+const std::string RAWTRANSACTION_DESCRIPTION =
+    "{\n"
+    "  \"in_active_chain\": b,   (boolean) Whether specified block is in the active chain or not (only present with explicit \"blockhash\" argument)\n"
+    "  \"hex\" : \"data\",       (string) The serialized, hex-encoded data for 'txid'\n"
+    "  \"txid\" : \"id\",        (string) The transaction id (same as provided)\n"
+    "  \"size\" : n,             (numeric) The transaction size\n"
+    "  \"version\" : n,          (numeric) The version\n"
+    "  \"locktime\" : ttt,       (numeric) The lock time\n"
+    "  \"expiryheight\" : ttt,   (numeric, optional) The block height after which the transaction expires\n"
+    "  \"vin\" : [               (array of json objects)\n"
+    "     {\n"
+    "       \"txid\": \"id\",    (string) The transaction id\n"
+    "       \"vout\": n,         (numeric) \n"
+    "       \"scriptSig\": {     (json object) The script\n"
+    "         \"asm\": \"asm\",  (string) asm\n"
+    "         \"hex\": \"hex\"   (string) hex\n"
+    "       },\n"
+    "       \"sequence\": n      (numeric) The script sequence number\n"
+    "     }\n"
+    "     ,...\n"
+    "  ],\n"
+    "  \"vout\" : [              (array of json objects)\n"
+    "     {\n"
+    "       \"value\" : x.xxx,            (numeric) The value in " +
+    CURRENCY_UNIT +
+    "\n"
+    "       \"n\" : n,                    (numeric) index\n"
+    "       \"scriptPubKey\" : {          (json object)\n"
+    "         \"asm\" : \"asm\",          (string) the asm\n"
+    "         \"hex\" : \"hex\",          (string) the hex\n"
+    "         \"reqSigs\" : n,            (numeric) The required sigs\n"
+    "         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n"
+    "         \"addresses\" : [           (json array of string)\n"
+    "           \"zcashaddress\"          (string) Zcash address\n"
+    "           ,...\n"
+    "         ]\n"
+    "       }\n"
+    "     }\n"
+    "     ,...\n"
+    "  ],\n"
+    "  \"vjoinsplit\" : [        (array of json objects, only for version >= 2)\n"
+    "     {\n"
+    "       \"vpub_old\" : x.xxx,         (numeric) public input value in " +
+    CURRENCY_UNIT +
+    "\n"
+    "       \"vpub_new\" : x.xxx,         (numeric) public output value in " +
+    CURRENCY_UNIT +
+    "\n"
+    "       \"anchor\" : \"hex\",         (string) the anchor\n"
+    "       \"nullifiers\" : [            (json array of string)\n"
+    "         \"hex\"                     (string) input note nullifier\n"
+    "         ,...\n"
+    "       ],\n"
+    "       \"commitments\" : [           (json array of string)\n"
+    "         \"hex\"                     (string) output note commitment\n"
+    "         ,...\n"
+    "       ],\n"
+    "       \"onetimePubKey\" : \"hex\",  (string) the onetime public key used to encrypt the ciphertexts\n"
+    "       \"randomSeed\" : \"hex\",     (string) the random seed\n"
+    "       \"macs\" : [                  (json array of string)\n"
+    "         \"hex\"                     (string) input note MAC\n"
+    "         ,...\n"
+    "       ],\n"
+    "       \"proof\" : \"hex\",          (string) the zero-knowledge proof\n"
+    "       \"ciphertexts\" : [           (json array of string)\n"
+    "         \"hex\"                     (string) output note ciphertext\n"
+    "         ,...\n"
+    "       ]\n"
+    "     }\n"
+    "     ,...\n"
+    "  ],\n"
+    "  \"blockhash\" : \"hash\",   (string) the block hash\n"
+    "  \"confirmations\" : n,      (numeric) The confirmations\n"
+    "  \"time\" : ttt,             (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT)\n"
+    "  \"blocktime\" : ttt         (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
+    "}\n";
+
+const std::string GETRAWTRANSACTION_HELP =
+    "getrawtransaction \"txid\" ( verbose \"blockhash\" )\n"
+    "\nNOTE: If \"blockhash\" is not provided and the -txindex option is not enabled, then this call only\n"
+    "works for mempool transactions. If either \"blockhash\" is provided or the -txindex option is\n"
+    "enabled, it also works for blockchain transactions. If the block which contains the transaction\n"
+    "is known, its hash can be provided even for nodes without -txindex. Note that if a blockhash is\n"
+    "provided, only that block will be searched and if the transaction is in the mempool or other\n"
+    "blocks, or if this node does not have the given block available, the transaction will not be found.\n"
+    "\nReturn the raw transaction data.\n"
+    "\nIf verbose=0, returns a string that is serialized, hex-encoded data for 'txid'.\n"
+    "If verbose is non-zero, returns an Object with information about 'txid'.\n"
+
+    "\nArguments:\n"
+    "1. \"txid\"      (string, required) The transaction id\n"
+    "2. verbose     (numeric, optional, default=0) If 0, return a string of hex-encoded data, otherwise return a JSON object\n"
+    "3. \"blockhash\" (string, optional) The block in which to look for the transaction\n"
+
+    "\nResult (if verbose is not set or set to 0):\n"
+    "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n"
+
+    "\nResult (if verbose > 0):\n" +
+    RAWTRANSACTION_DESCRIPTION +
+    "\nExamples:\n";
+
+#endif


### PR DESCRIPTION
The RPC help documentation has been produced by multiple programmers working on multiple projects over more than a decade.  In spite of this, they are thoughtfully written with clear notation and remarkable consistency.   

This update incorporates substantial improvements to consistency and readability by using a simple template across all RPC help documents.

Improvements Include:

  1. a Single Source of Truth for the [RPC documentation format](https://github.com/zancas/zcash/blob/afb658b9d9e308d9b36a52937a7f579dc7d0aebe/src/rpc/docstrings.h#L6)
  2. inclusion of _all_ available RPCs in the zcash-cli help listing (possibly deactivating dangerous/obsolete ones)
  3. defensive checks of parameter number-and-type per RPC

Help documentation _MUST_ have `Usage` `Description` `Result` and `Examples` sections, it may also contain an optional `Argument` section.

Examples of Improvements:

`getconnectioncount`:
 Because the task of labeling sections is now handled by the template, rather than idiosyncratically on a per-developer/per-RPC basis, typos like the `bResult:` in `getconnectioncount` won't occur:

Current Release:
![getconnectioncount_master](https://user-images.githubusercontent.com/640955/117883321-82754b00-b268-11eb-8965-96bfb8c73975.png)

Feature Branch:
![getconnectioncount_feature](https://user-images.githubusercontent.com/640955/117883389-991ba200-b268-11eb-9f71-4da16fe27bdd.png)

(Note:  This typo occurs elsewhere.)